### PR TITLE
Publish model updates on the main thread while fine tuneing

### DIFF
--- a/LLMFarm/Tune/FineTuneModel.swift
+++ b/LLMFarm/Tune/FineTuneModel.swift
@@ -62,8 +62,10 @@ final class FineTuneModel: ObservableObject {
     
     public func finetune() async {
         Task{
-            self.tune_log = ""
-            self.state = .loading
+            DispatchQueue.main.async {
+                self.tune_log = ""
+                self.state = .loading
+            }
             let documents_path = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first
             let model_path = get_path_by_short_name(model_file_path,dest:"models")
             if (model_path == nil || documents_path == nil){


### PR DESCRIPTION
This change should take care of the following warning:

`Publishing changes from background threads is not allowed; make sure to publish values from the main thread (via operators like receive(on:)) on model updates.
`