### PR TITLE
Docs: Spelling Corrections in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ See full list [here](https://github.com/ggerganov/llama.cpp).
 - [x] [Yi-VL](https://huggingface.co/models?search=Yi-VL)
 - [x] [Moondream](https://huggingface.co/vikhyatk/moondream2)
   
-Note: For *Falcon, Alpaca, GPT4All, Chinese LLaMA / Alpaca and Chinese LLaMA-2 / Alpaca-2, Vigogne (French), Vicuna, Koala, OpenBuddy (Multilingual), Pygmalion/Metharme, WizardLM, Baichuan 1 & 2 + derivations, Aquila 1 & 2, Mistral AI v0.1, Refact, Persimmon 8B, MPT, Bloom* select `llama inferece` in model settings.
+Note: For *Falcon, Alpaca, GPT4All, Chinese LLaMA / Alpaca and Chinese LLaMA-2 / Alpaca-2, Vigogne (French), Vicuna, Koala, OpenBuddy (Multilingual), Pygmalion/Metharme, WizardLM, Baichuan 1 & 2 + derivations, Aquila 1 & 2, Mistral AI v0.1, Refact, Persimmon 8B, MPT, Bloom* select `llama inference` in model settings.
 
 # Sampling methods
 - [x] Temperature (temp, tok-k, top-p)


### PR DESCRIPTION
## Description
This pull request addresses spelling errors in the README file of our project.

## Changes Made
- Corrected spelling of inferece to inference 


## Checklist
- [x] I have reviewed my changes for any additional typos
- [x] The README still renders correctly in markdown
- [x] No code changes were made in this PR

## Additional Information:
This fix is not related to any existing issue. It's a minor typo that I noticed while reviewing the README.

Thank you for considering this contribution.
